### PR TITLE
Change 'hazelcast' dependency scope to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
To be consistent with other plugins. For the other plugins (AWS, Kubernetes, Eureka) we already have the scope 'provided'. For GCP, there is already a PR sent: https://github.com/hazelcast/hazelcast-gcp/pull/15