### PR TITLE
Added use-instance-metadata property

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 * [Introduction](#hazelcast-discovery-plugin-for-microsoft-azure)
 * [Getting Started](#getting-started)
-* [Compiling with Gradle](#compiling-with-gradle)
 * [Using the Plugin](#using-the-plugin)
     * [Configuration when Azure Instance Metadata Service is available](#configuration-when-azure-instance-metadata-service-is-available)
     * [Configuration when Azure Instance Metadata Service is NOT available](#configuration-when-azure-instance-metadata-service-is-not-available)
@@ -44,19 +43,11 @@ For Maven:
 </dependencies>
 ```
 
-# Compiling with Gradle
-
-Run the following command to compile the plugin:
-
-```gradle
-compile 'com.hazelcast.azure:hazelcast-azure:${hazelcast-azure-version}'
-```
-
 Check the [releases](https://github.com/hazelcast/hazelcast-azure/releases) for the latest version.
 
 # Using the Plugin
 
-Firstly, please ensure that you have added the package `hazelcast-azure` to your Maven or Gradle configuration as mentioned above. 
+Firstly, please ensure that you have added the `hazelcast-azure` dependency to your Maven or Gradle configuration as mentioned above. 
 
 ## Configuration when Azure Instance Metadata Service is available
 
@@ -138,7 +129,7 @@ If so, then Hazelcast instances should be configured with the properties as show
     <join>
       <multicast enabled="false"/>
       <azure enabled="true">
-        <use-instance-metadata>false</use-instance-metadata>
+        <instance-metadata-available>false</instance-metadata-available>
         <client-id>CLIENT_ID</client-id>
         <client-secret>CLIENT_SECRET</client-secret>
         <tenant-id>TENANT_ID</tenant-id>
@@ -161,7 +152,7 @@ hazelcast:
         enabled: false
       azure:
         enabled: true
-        use-instance-metadata: false
+        instance-metadata-available: false
         client-id: CLIENT_ID
         tenant-id: TENANT_ID
         client-secret: CLIENT_SECRET
@@ -173,7 +164,7 @@ hazelcast:
 ```
 You will need to setup [Azure Active Directory Service Principal credentials](https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/) for your Azure Subscription to be able to use these properties. 
 
-- `use-instance-metadata` - This property should be configured as `false` in order to be able to use the following properties. It is `true` by default.
+- `instance-metadata-available` - This property should be configured as `false` in order to be able to use the following properties. It is `true` by default.
 - `client-id` - The Azure Active Directory Service Principal client ID.
 - `client-secret` - The Azure Active Directory Service Principal client secret.
 - `tenant-id` - The Azure Active Directory tenant ID.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 * [Discovery Implementation for Azure Services](#discovery-implementation-for-azure-services)
 * [Getting Started](#getting-started)
 * [Compiling with Gradle](#compiling-with-gradle)
-* [Configuring at Hazelcast Side](#configuring-at-hazelcast-side)
-* [Configuring at Azure Side](#configuring-at-azure-side)
-* [Using Azure With ZONE_AWARE Partition Group](#using-azure-with-zone_aware-partition-group)
+* [Using the Plugin](#using-the-plugin)
+    * [Configuration when Azure Instance Metadata Service is available](#configuration-when-azure-instance-metadata-service-is-available)
+    * [Configuration when Azure Instance Metadata Service is NOT available](#configuration-when-azure-instance-metadata-service-is-not-available)
+    * [Additional Properties](#additional-properties)
+    * [ZONE_AWARE Partition Group](#zone_aware-partition-group)
+    * [Configuring with Public IP Addresses](#configuring-with-public-ip-addresses)
 * [Automated Deployment](#automated-deployment)
 
 
@@ -51,11 +54,17 @@ compile 'com.hazelcast.azure:hazelcast-azure:${hazelcast-azure-version}'
 
 Check the [releases](https://github.com/hazelcast/hazelcast-azure/releases) for the latest version.
 
-# Configuring at Hazelcast Side
+# Using the Plugin
 
-Ensure that you have added the package `hazelcast-azure` to your Maven or Gradle configuration as mentioned above.
+Firstly, please ensure that you have added the package `hazelcast-azure` to your Maven or Gradle configuration as mentioned above. 
 
-In your Hazelcast configuration, use the `AzureDiscoveryStrategy` as shown below:
+## Configuration when Azure Instance Metadata Service is available
+
+Hazelcast Azure Plugin can use [Azure Instance Metadata Service](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service) to get access token and other environment details. 
+
+You will need just the following minimal configuration to setup Hazelcast Azure Discovery if:
+- Azure Instance Metadata Service is available. The Hazelcast instances (clients or members) should run in an Azure VM to make use of Azure Instance Metadata Service.  
+- [Azure managed identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) with the correct access roles are setup. 
 
 #### XML Configuration:
 ```xml
@@ -63,16 +72,7 @@ In your Hazelcast configuration, use the `AzureDiscoveryStrategy` as shown below
   <network>
     <join>
       <multicast enabled="false"/>
-      <azure enabled="true">
-        <client-id>CLIENT_ID</client-id>
-        <client-secret>CLIENT_SECRET</client-secret>
-        <tenant-id>TENANT_ID</tenant-id>
-        <subscription-id>SUB_ID</subscription-id>
-        <resource-group>RESOURCE-GROUP-NAME</resource-group>
-        <scale-set>SCALE-SET-NAME</scale-set>
-        <tag>TAG-NAME=HZLCAST001</tag>
-        <hz-port>5701-5703</hz-port>
-      </azure>
+      <azure enabled="true"/>
     </join>
   </network>
 </hazelcast>
@@ -86,39 +86,13 @@ hazelcast:
         enabled: false
       azure:
         enabled: true
-        client-id: CLIENT_ID
-        tenant-id: TENANT_ID
-        client-secret: CLIENT_SECRET
-        subscription-id: SUB_ID
-        resource-group: RESOURCE-GROUP-NAME
-        scale-set: SCALE-SET-NAME
-        tag: TAG-NAME=HZLCAST001
-        hz-port: 5701-5703
 ```
 
-You will need to setup [Azure Active Directory Service Principal credentials](https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/) for your Azure Subscription for this plugin to work. With the credentials, fill in the placeholder values above.
+The other necessary information such as subscription ID and and resource group name will be retrieved from instance metadata service. This method allows to run the plugin without keeping any secret or password in the code or configuration.
 
-# Configuring at Azure Side
+#### Note
 
-- `client-id` - *(Optional)* The Azure Active Directory Service Principal client ID.
-- `client-secret` - *(Optional)* The Azure Active Directory Service Principal client secret.
-- `tenant-id` - *(Optional)* The Azure Active Directory tenant ID.
-- `subscription-id` - *(Optional)* The Azure subscription ID.
-- `resource-group` - *(Optional)* The Azure [resource group](https://azure.microsoft.com/en-us/documentation/articles/resource-group-portal/) name of the cluster. You can find this in the Azure [portal](https://portal.azure.com) or [CLI](https://npmjs.org/azure-cli).
-- `scale-set` - *(Optional)* The Azure [VM scale set](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/overview) name of the cluster. If this setting is configured, the plugin will search for instances over the resources only within this scale set.
-- `tag` - *(Optional)* The key-value pair of the tag on the Hazelcast vm resources. The format should be as `key=value`.
-- `hz-port` - *(Optional)* The port range where Hazelcast is expected to be running. The format should be as `5701` or `5701-5703`. The default value is "5701-5703".
-
-**Notes**
-
-* You should configure all or none of `client-id`, `client-secret`, and `tenant-id` settings. If you *do not* configure all of them, the plugin will try to retrieve the Azure REST API access token from the [instance metadata service](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service). 
-* If you use the plugin in the Hazelcast Client running outside of the Azure network, then the following settings are mandatory:  `client-id`, `client-secret`, and `tenant-id`     
-* If you *do not* configure any of the `subscription-id`, `resource-group`, or `scale-set` settings, again the plugin will try to retrieve these settings' current values using instance metadata service.
-* If you *do not* configure `tag` setting, the plugin will search for instances over all available resources. 
-
-The only requirement is that every VM can access each other either by private or public IP address. Also, the resources should have the managed identity with correct access roles in order to use instance metadata service.
-
-If you don't setup the correct access roles on Azure environment and try to use plugin without `client-id`, `client-secret`, and `tenant-id` settings, then you will see an exception similar below:
+If you don't setup the correct access roles on Azure environment, then you will see an exception similar below:
 
 ```
 WARNING: Cannot discover nodes, returning empty list
@@ -149,9 +123,13 @@ Caused by: com.hazelcast.azure.RestClientException: Failure executing: GET at: h
         ... 20 more
 ```
 
-## Minimal Configuration Example
+## Configuration when Azure Instance Metadata Service is NOT available
+ 
+There may be occasions that [Azure Instance Metadata Service](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service) is not available, such as:
+- Hazelcast instances (clients or WAN Replication cluster members) might be running outside of an Azure VM.
+- [Azure managed identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) are not setup or available.
 
-If you setup your Azure managed identities with the correct access roles, you will need just the following minimal configuration to setup Hazelcast Azure Discovery:
+If so, then Hazelcast instances should be configured with the properties as shown below:
 
 #### XML Configuration:
 ```xml
@@ -159,7 +137,17 @@ If you setup your Azure managed identities with the correct access roles, you wi
   <network>
     <join>
       <multicast enabled="false"/>
-      <azure enabled="true"/>
+      <azure enabled="true">
+        <use-instance-metadata>false</use-instance-metadata>
+        <client-id>CLIENT_ID</client-id>
+        <client-secret>CLIENT_SECRET</client-secret>
+        <tenant-id>TENANT_ID</tenant-id>
+        <subscription-id>SUB_ID</subscription-id>
+        <resource-group>RESOURCE-GROUP-NAME</resource-group>
+        <scale-set>SCALE-SET-NAME</scale-set>
+        <tag>TAG-NAME=HZLCAST001</tag>
+        <hz-port>5701-5703</hz-port>
+      </azure>
     </join>
   </network>
 </hazelcast>
@@ -173,9 +161,34 @@ hazelcast:
         enabled: false
       azure:
         enabled: true
+        use-instance-metadata: false
+        client-id: CLIENT_ID
+        tenant-id: TENANT_ID
+        client-secret: CLIENT_SECRET
+        subscription-id: SUB_ID
+        resource-group: RESOURCE-GROUP-NAME
+        scale-set: SCALE-SET-NAME
+        tag: TAG-NAME=HZLCAST001
+        hz-port: 5701-5703
 ```
+You will need to setup [Azure Active Directory Service Principal credentials](https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/) for your Azure Subscription to be able to use these properties. 
 
-# Using Azure With ZONE_AWARE Partition Group
+- `use-instance-metadata` - This property should be configured as `false` in order to be able to use the following properties. It is `true` by default.
+- `client-id` - The Azure Active Directory Service Principal client ID.
+- `client-secret` - The Azure Active Directory Service Principal client secret.
+- `tenant-id` - The Azure Active Directory tenant ID.
+- `subscription-id` - The Azure subscription ID.
+- `resource-group` - The name of Azure [resource group](https://azure.microsoft.com/en-us/documentation/articles/resource-group-portal/) which the Hazelcast instance is running in.
+- `scale-set` - *(Optional)* The name of Azure [VM scale set](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/overview). If this setting is configured, the plugin will search for instances over the resources only within this scale set.
+
+## Additional Properties
+
+The following properties can be configured at any of the circumstances above.  
+
+- `tag` - *(Optional)* The key-value pair of the tag on the Azure VM resources. The format should be as `key=value`. If this setting is configured, the plugin will search for instances over only the resources that have this tag entry. If not configured, the plugin will search for instances over all available resources.
+- `hz-port` - *(Optional)* The port range where Hazelcast is expected to be running. The format should be as `5701` or `5701-5703`. The default value is `5701-5703`.
+
+## ZONE_AWARE Partition Group
 
 When you use Azure plugin as discovery provider, you can configure Hazelcast Partition Grouping with Azure. You need to add fault domain or DNS domain to your machines. So machines will be grouped with respect to their fault or DNS domains.
 For more information please read: http://docs.hazelcast.org/docs/3.7/manual/html-single/index.html#partition-group-configuration.
@@ -184,7 +197,7 @@ For more information please read: http://docs.hazelcast.org/docs/3.7/manual/html
 <partition-group enabled="true" group-type="ZONE_AWARE" />
 ```
 
-# Using the Plugin with Public IP Addresses
+## Configuring with Public IP Addresses
 
 If you would like to use Azure Discovery Plugin to discover Hazelcast instances using public IPs, please note that you need to set the following two configurations:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Table of Contents
 
-* [Discovery Implementation for Azure Services](#discovery-implementation-for-azure-services)
+* [Introduction](#hazelcast-discovery-plugin-for-microsoft-azure)
 * [Getting Started](#getting-started)
 * [Compiling with Gradle](#compiling-with-gradle)
 * [Using the Plugin](#using-the-plugin)

--- a/src/main/java/com/hazelcast/azure/AzureClient.java
+++ b/src/main/java/com/hazelcast/azure/AzureClient.java
@@ -62,7 +62,7 @@ class AzureClient {
     }
 
     private String resourceGroupFromConfigOrMetadataApi() {
-        if (!azureConfig.isUseInstanceMetadata()) {
+        if (!azureConfig.isInstanceMetadataAvailable()) {
             return azureConfig.getResourceGroup();
         }
         LOGGER.finest("Property 'resourceGroup' not configured, fetching from the VM metadata service");
@@ -70,7 +70,7 @@ class AzureClient {
     }
 
     private String scaleSetFromConfigOrMetadataApi() {
-        if (!azureConfig.isUseInstanceMetadata()) {
+        if (!azureConfig.isInstanceMetadataAvailable()) {
             return azureConfig.getScaleSet();
         }
         LOGGER.finest("Property 'scaleSet' not configured, fetching from the VM metadata service");
@@ -91,7 +91,7 @@ class AzureClient {
     }
 
     private String fetchAccessToken() {
-        if (azureConfig.isUseInstanceMetadata()) {
+        if (azureConfig.isInstanceMetadataAvailable()) {
             return azureMetadataApi.accessToken();
         } else {
             return azureAuthenticator.refreshAccessToken(azureConfig.getTenantId(), azureConfig.getClientId(),

--- a/src/main/java/com/hazelcast/azure/AzureComputeApi.java
+++ b/src/main/java/com/hazelcast/azure/AzureComputeApi.java
@@ -27,7 +27,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static com.hazelcast.azure.Utils.isBlank;
+import static com.hazelcast.azure.Utils.isEmpty;
 
 /**
  * Responsible for connecting to the Azure Cloud Compute API.
@@ -80,7 +80,7 @@ class AzureComputeApi {
     }
 
     private String urlForPrivateIpList(String subscriptionId, String resourceGroup, String scaleSet) {
-        if (isBlank(scaleSet)) {
+        if (isEmpty(scaleSet)) {
             return String.format("%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network"
                     + "/networkInterfaces?api-version=%s", endpoint, subscriptionId, resourceGroup, API_VERSION);
         } else {
@@ -106,7 +106,7 @@ class AzureComputeApi {
                     JsonObject ipProps = ipConfiguration.asObject().get("properties").asObject();
                     String privateIp = ipProps.getString("privateIPAddress", null);
                     String publicIpId = toJsonObject(ipProps.get("publicIPAddress")).getString("id", null);
-                    if (!isBlank(publicIpId)) {
+                    if (!isEmpty(publicIpId)) {
                         interfaces.put(publicIpId, new AzureNetworkInterface(privateIp, publicIpId, tagList));
                     }
                 }
@@ -116,7 +116,7 @@ class AzureComputeApi {
     }
 
     private String urlForPublicIpList(String subscriptionId, String resourceGroup, String scaleSet) {
-        if (isBlank(scaleSet)) {
+        if (isEmpty(scaleSet)) {
             return String.format("%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network"
                     + "/publicIPAddresses?api-version=%s", endpoint, subscriptionId, resourceGroup, API_VERSION);
         } else {
@@ -132,7 +132,7 @@ class AzureComputeApi {
         for (JsonValue item : toJsonArray(Json.parse(response).asObject().get("value"))) {
             String id = item.asObject().getString("id", null);
             String ip = toJsonObject(item.asObject().get("properties")).getString("ipAddress", null);
-            if (!isBlank(ip)) {
+            if (!isEmpty(ip)) {
                 publicIps.put(id, ip);
             }
         }

--- a/src/main/java/com/hazelcast/azure/AzureConfig.java
+++ b/src/main/java/com/hazelcast/azure/AzureConfig.java
@@ -28,7 +28,7 @@ final class AzureConfig {
     private String scaleSet;
     private Tag tag;
     private PortRange hzPort;
-    private Boolean useInstanceMetadata;
+    private Boolean instanceMetadataAvailable;
 
     private AzureConfig() {
     }
@@ -69,8 +69,8 @@ final class AzureConfig {
         return hzPort;
     }
 
-    public Boolean isUseInstanceMetadata() {
-        return useInstanceMetadata;
+    public Boolean isInstanceMetadataAvailable() {
+        return instanceMetadataAvailable;
     }
 
     static final class Builder {
@@ -121,8 +121,8 @@ final class AzureConfig {
             return this;
         }
 
-        Builder setUseInstanceMetadata(Boolean useInstanceMetadata) {
-            this.config.useInstanceMetadata = useInstanceMetadata;
+        Builder setInstanceMetadataAvailable(Boolean instanceMetadataAvailable) {
+            this.config.instanceMetadataAvailable = instanceMetadataAvailable;
             return this;
         }
 

--- a/src/main/java/com/hazelcast/azure/AzureConfig.java
+++ b/src/main/java/com/hazelcast/azure/AzureConfig.java
@@ -28,6 +28,7 @@ final class AzureConfig {
     private String scaleSet;
     private Tag tag;
     private PortRange hzPort;
+    private Boolean useInstanceMetadata;
 
     private AzureConfig() {
     }
@@ -66,6 +67,10 @@ final class AzureConfig {
 
     PortRange getHzPort() {
         return hzPort;
+    }
+
+    public Boolean isUseInstanceMetadata() {
+        return useInstanceMetadata;
     }
 
     static final class Builder {
@@ -113,6 +118,11 @@ final class AzureConfig {
 
         Builder setHzPort(PortRange hzPort) {
             this.config.hzPort = hzPort;
+            return this;
+        }
+
+        Builder setUseInstanceMetadata(Boolean useInstanceMetadata) {
+            this.config.useInstanceMetadata = useInstanceMetadata;
             return this;
         }
 

--- a/src/main/java/com/hazelcast/azure/AzureDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/azure/AzureDiscoveryStrategy.java
@@ -40,7 +40,7 @@ import static com.hazelcast.azure.AzureProperties.RESOURCE_GROUP;
 import static com.hazelcast.azure.AzureProperties.SCALE_SET;
 import static com.hazelcast.azure.AzureProperties.SUBSCRIPTION_ID;
 import static com.hazelcast.azure.AzureProperties.TENANT_ID;
-import static com.hazelcast.azure.AzureProperties.USE_INSTANCE_METADATA;
+import static com.hazelcast.azure.AzureProperties.INSTANCE_METADATA_AVAILABLE;
 import static com.hazelcast.azure.Utils.isAllFilled;
 import static com.hazelcast.azure.Utils.isAnyFilled;
 
@@ -89,9 +89,9 @@ public class AzureDiscoveryStrategy extends AbstractDiscoveryStrategy {
                                              .setHzPort(
                                                      new PortRange((String) getOrDefault(PORT.getDefinition(),
                                                              PORT.getDefaultValue())))
-                                             .setUseInstanceMetadata(
-                                                     (Boolean) getOrDefault(USE_INSTANCE_METADATA.getDefinition(),
-                                                             USE_INSTANCE_METADATA.getDefaultValue()))
+                                             .setInstanceMetadataAvailable(
+                                                     (Boolean) getOrDefault(INSTANCE_METADATA_AVAILABLE.getDefinition(),
+                                                             INSTANCE_METADATA_AVAILABLE.getDefaultValue()))
                                              .build();
         validate(azureConfig);
         return azureConfig;
@@ -110,8 +110,8 @@ public class AzureDiscoveryStrategy extends AbstractDiscoveryStrategy {
     }
 
     private void validate(AzureConfig azureConfig) {
-        if (!azureConfig.isUseInstanceMetadata()) {
-            LOGGER.info("useInstanceMetadata is set to false, validating other properties...");
+        if (!azureConfig.isInstanceMetadataAvailable()) {
+            LOGGER.info("instance-metadata-available is set to false, validating other properties...");
             if (!isAllFilled(azureConfig.getTenantId(),
                     azureConfig.getClientId(),
                     azureConfig.getClientSecret(),

--- a/src/main/java/com/hazelcast/azure/AzureProperties.java
+++ b/src/main/java/com/hazelcast/azure/AzureProperties.java
@@ -83,8 +83,9 @@ enum AzureProperties {
     PORT("hz-port", STRING, true, "5701-5703"),
 
     /**
-     * Property to enable/disable usage of Azure Instance Metadata service when retrieving current configuration parameters. Should be
-     * set to false when using the plugin outside of Azure Environment or Azure Instance Metadata service is not available.
+     * Property to enable/disable usage of Azure Instance Metadata service when retrieving current configuration parameters.
+     * Should be set to false when using the plugin outside of Azure Environment or Azure Instance Metadata service is not
+     * available.
      * <p/>
      * When set to <code>false<code/>, ALL of <code>tenantId</code>, <code>clientId</code>, <code>clientSecret</code>,
      * <code>subscriptionId</code>, and <code>resourceGroup</code> properties should be configured. When set to <code>true<code>,

--- a/src/main/java/com/hazelcast/azure/AzureProperties.java
+++ b/src/main/java/com/hazelcast/azure/AzureProperties.java
@@ -19,6 +19,7 @@ import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.PropertyTypeConverter;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
 
+import static com.hazelcast.config.properties.PropertyTypeConverter.BOOLEAN;
 import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 
 /**
@@ -27,50 +28,43 @@ import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 enum AzureProperties {
 
     /**
-     * The tenant-id of the Azure account. This property should be provided with <code>client-id<code/>
-     * and <code>client-secret</code>. If none of them are provided, then the authentication is tried to be done using
-     * Azure VM instance metadata service.
+     * The tenant-id of the Azure account. This property can be used only if <code>use-instance-metadata</code> property
+     * is set to <code>false</code>. Otherwise, the authentication token will be retrieved the Azure VM instance metadata service.
      */
     TENANT_ID("tenant-id", STRING, true),
 
     /**
-     * The client-id of the Azure account. This property should be provided with <code>tenant-id<code/>
-     * and <code>client-secret</code>. If none of them are provided, then the authentication is tried to be done using
-     * Azure VM instance metadata service.
+     * The client-id of the Azure account. This property can be used only if <code>use-instance-metadata</code> property
+     * is set to <code>false</code>. Otherwise, the authentication token will be retrieved the Azure VM instance metadata service.
      */
     CLIENT_ID("client-id", STRING, true),
 
     /**
-     * The client-secret of the Azure account. This property should be provided with <code>tenant-id<code/>
-     * and <code>client-id</code>. If none of them are provided, then the authentication is tried to be done using
-     * Azure VM instance metadata service.
+     * The client-secret of the Azure account. This property can be used only if <code>use-instance-metadata</code> property
+     * is set to <code>false</code>. Otherwise, the authentication token will be retrieved the Azure VM instance metadata service.
      */
     CLIENT_SECRET("client-secret", STRING, true),
 
     /**
      * ID of the Azure subscription that VMs/SM Scale Set created.
-     * If not specified, then the <code>subscription-id</code> is taken from the Azure VM instance metadata service.
-     * Instances connecting outside of Azure or from a different resource group should define the correct
-     * <code>subscription-id</code>
+     * This property can be used only if <code>use-instance-metadata</code> property is set to <code>false</code>.
+     * Otherwise, the <code>subscription-id</code> will be retrieved the Azure VM instance metadata service.
      */
     SUBSCRIPTION_ID("subscription-id", STRING, true),
 
     /**
      * Name of the Azure resource group that VMs/SM Scale Set created.
-     * If not specified, then the <code>resource-group</code> is taken from the Azure VM instance metadata service.
-     * Instances connecting outside of Azure or from a different resource group should define the correct
-     * <code>resource-group</code>
+     * This property can be used only if <code>use-instance-metadata</code> property is set to <code>false</code>.
+     * Otherwise, the <code>resource-group</code> will be retrieved the Azure VM instance metadata service.
      */
     RESOURCE_GROUP("resource-group", STRING, true),
 
     /**
      * Name of the Azure VM scale set that VMs are created.
-     * If not specified, then the <code>scale-set</code> is taken from the Azure VM instance metadata service.
-     * Instances connecting outside of Azure or from a different resource group should define the correct
-     * <code>scale-set</code>.
+     * This property can be used only if <code>use-instance-metadata</code> property is set to <code>false</code>.
+     * Otherwise, the <code>scale-set</code> will be retrieved the Azure VM instance metadata service.
      * <p>
-     * Please note that the discovery will be performed only in this scale-set when this property
-     * has a value.
+     * Please note that the discovery will be performed only in this scale-set when this property has a value.
      */
     SCALE_SET("scale-set", STRING, true),
 
@@ -86,7 +80,20 @@ enum AzureProperties {
      * <p>
      * The default value is "5701-5703".
      */
-    PORT("hz-port", STRING, true, "5701-5703");
+    PORT("hz-port", STRING, true, "5701-5703"),
+
+    /**
+     * Property to enable/disable Azure Instance Metadata service when retrieving current configuration parameters. Should be
+     * set to false when using the plugin outside of Azure Environment or Azure Instance Metadata service is not available.
+     * <p/>
+     * When set to <code>false<code/>, ALL of <code>tenantId</code>, <code>clientId</code>, <code>clientSecret</code>,
+     * <code>subscriptionId</code>, and <code>resourceGroup</code> properties should be configured. When set to <code>true<code>,
+     * NONE of <code>tenantId</code>, <code>clientId</code>, <code>clientSecret</code>, <code>subscriptionId</code>,
+     * <code>resourceGroup</code>, and <code>scaleSet</code> properties should be configured.
+     * <p/>
+     * The default value is <code>true</code>.
+     */
+    USE_INSTANCE_METADATA("use-instance-metadata", BOOLEAN, true, Boolean.TRUE);
 
     private final PropertyDefinition propertyDefinition;
     private final Comparable defaultValue;

--- a/src/main/java/com/hazelcast/azure/AzureProperties.java
+++ b/src/main/java/com/hazelcast/azure/AzureProperties.java
@@ -28,40 +28,40 @@ import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 enum AzureProperties {
 
     /**
-     * The tenant-id of the Azure account. This property can be used only if <code>use-instance-metadata</code> property
+     * The tenant-id of the Azure account. This property can be used only if <code>instance-metadata-available</code> property
      * is set to <code>false</code>. Otherwise, the authentication token will be retrieved the Azure VM instance metadata service.
      */
     TENANT_ID("tenant-id", STRING, true),
 
     /**
-     * The client-id of the Azure account. This property can be used only if <code>use-instance-metadata</code> property
+     * The client-id of the Azure account. This property can be used only if <code>instance-metadata-available</code> property
      * is set to <code>false</code>. Otherwise, the authentication token will be retrieved the Azure VM instance metadata service.
      */
     CLIENT_ID("client-id", STRING, true),
 
     /**
-     * The client-secret of the Azure account. This property can be used only if <code>use-instance-metadata</code> property
+     * The client-secret of the Azure account. This property can be used only if <code>instance-metadata-available</code> property
      * is set to <code>false</code>. Otherwise, the authentication token will be retrieved the Azure VM instance metadata service.
      */
     CLIENT_SECRET("client-secret", STRING, true),
 
     /**
      * ID of the Azure subscription that VMs/SM Scale Set created.
-     * This property can be used only if <code>use-instance-metadata</code> property is set to <code>false</code>.
+     * This property can be used only if <code>instance-metadata-available</code> property is set to <code>false</code>.
      * Otherwise, the <code>subscription-id</code> will be retrieved the Azure VM instance metadata service.
      */
     SUBSCRIPTION_ID("subscription-id", STRING, true),
 
     /**
      * Name of the Azure resource group that VMs/SM Scale Set created.
-     * This property can be used only if <code>use-instance-metadata</code> property is set to <code>false</code>.
+     * This property can be used only if <code>instance-metadata-available</code> property is set to <code>false</code>.
      * Otherwise, the <code>resource-group</code> will be retrieved the Azure VM instance metadata service.
      */
     RESOURCE_GROUP("resource-group", STRING, true),
 
     /**
      * Name of the Azure VM scale set that VMs are created.
-     * This property can be used only if <code>use-instance-metadata</code> property is set to <code>false</code>.
+     * This property can be used only if <code>instance-metadata-available</code> property is set to <code>false</code>.
      * Otherwise, the <code>scale-set</code> will be retrieved the Azure VM instance metadata service.
      * <p>
      * Please note that the discovery will be performed only in this scale-set when this property has a value.
@@ -94,7 +94,7 @@ enum AzureProperties {
      * <p/>
      * The default value is <code>true</code>.
      */
-    USE_INSTANCE_METADATA("use-instance-metadata", BOOLEAN, true, Boolean.TRUE);
+    INSTANCE_METADATA_AVAILABLE("instance-metadata-available", BOOLEAN, true, Boolean.TRUE);
 
     private final PropertyDefinition propertyDefinition;
     private final Comparable defaultValue;

--- a/src/main/java/com/hazelcast/azure/AzureProperties.java
+++ b/src/main/java/com/hazelcast/azure/AzureProperties.java
@@ -83,7 +83,7 @@ enum AzureProperties {
     PORT("hz-port", STRING, true, "5701-5703"),
 
     /**
-     * Property to enable/disable Azure Instance Metadata service when retrieving current configuration parameters. Should be
+     * Property to enable/disable usage of Azure Instance Metadata service when retrieving current configuration parameters. Should be
      * set to false when using the plugin outside of Azure Environment or Azure Instance Metadata service is not available.
      * <p/>
      * When set to <code>false<code/>, ALL of <code>tenantId</code>, <code>clientId</code>, <code>clientSecret</code>,

--- a/src/main/java/com/hazelcast/azure/Utils.java
+++ b/src/main/java/com/hazelcast/azure/Utils.java
@@ -23,30 +23,31 @@ final class Utils {
     private Utils() {
     }
 
-    static boolean isBlank(final String string) {
+    static boolean isEmpty(final String string) {
         return string == null || string.trim().length() == 0;
     }
 
-    static boolean isAllBlank(final String... values) {
-        if (values != null) {
-            for (final String val : values) {
-                if (!isBlank(val)) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    static boolean isAllNotBlank(final String... values) {
+    static boolean isAllFilled(final String... values) {
         if (values == null) {
             return false;
         }
         for (final String val : values) {
-            if (isBlank(val)) {
+            if (isEmpty(val)) {
                 return false;
             }
         }
         return true;
+    }
+
+    static boolean isAnyFilled(final String... values) {
+        if (values == null) {
+            return false;
+        }
+        for (final String val : values) {
+            if (!isEmpty(val)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/test/java/com/hazelcast/azure/AzureClientTest.java
+++ b/src/test/java/com/hazelcast/azure/AzureClientTest.java
@@ -65,7 +65,7 @@ public class AzureClientTest {
         // given
         given(azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, SCALE_SET, null, ACCESS_TOKEN)).willReturn(ADDRESSES);
 
-        AzureConfig azureConfig = AzureConfig.builder().build();
+        AzureConfig azureConfig = AzureConfig.builder().setUseInstanceMetadata(true).build();
         AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
 
         // when
@@ -80,7 +80,7 @@ public class AzureClientTest {
         // given
         given(azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, SCALE_SET, TAG, ACCESS_TOKEN)).willReturn(ADDRESSES);
 
-        AzureConfig azureConfig = AzureConfig.builder().setTag(TAG).build();
+        AzureConfig azureConfig = AzureConfig.builder().setUseInstanceMetadata(true).setTag(TAG).build();
         AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
 
         // when
@@ -93,41 +93,25 @@ public class AzureClientTest {
     @Test
     public void getAddressesWithConfiguredSettings() {
         // given
+        String tenantId = "tenant-id";
+        String clientId = "client-id";
+        String clientSecret = "client-secret";
+        given(azureAuthenticator.refreshAccessToken(tenantId, clientId, clientSecret)).willReturn(ACCESS_TOKEN);
         String subscriptionId = "subscription-2";
         String resourceGroup = "resource-group-2";
         String scaleSet = "scale-set-2";
         given(azureComputeApi.instances(subscriptionId, resourceGroup, scaleSet, TAG, ACCESS_TOKEN)).willReturn(ADDRESSES);
 
         AzureConfig azureConfig = AzureConfig.builder()
+                                       .setClientId(clientId)
+                                       .setTenantId(tenantId)
+                                       .setClientSecret(clientSecret)
                                        .setSubscriptionId(subscriptionId)
                                        .setResourceGroup(resourceGroup)
                                        .setScaleSet(scaleSet)
+                                       .setUseInstanceMetadata(false)
                                        .setTag(TAG)
                                        .build();
-        AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
-
-        // when
-        Collection<AzureAddress> result = azureClient.getAddresses();
-
-        // then
-        assertEquals(ADDRESSES, result);
-    }
-
-    @Test
-    public void getAddressesWithAuthenticationSettings() {
-        // given
-        given(azureMetadataApi.accessToken()).willReturn(null);
-        String tenantId = "tenant-id";
-        String clientId = "client-id";
-        String clientSecret = "client-secret";
-        given(azureAuthenticator.refreshAccessToken(tenantId, clientId, clientSecret)).willReturn(ACCESS_TOKEN);
-        given(azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, SCALE_SET, null, ACCESS_TOKEN)).willReturn(ADDRESSES);
-
-        AzureConfig azureConfig = AzureConfig.builder()
-                                           .setClientId(clientId)
-                                           .setTenantId(tenantId)
-                                           .setClientSecret(clientSecret)
-                                           .build();
         AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
 
         // when
@@ -143,7 +127,7 @@ public class AzureClientTest {
         String location = "location-1";
         given(azureMetadataApi.location()).willReturn(location);
         given(azureMetadataApi.availabilityZone()).willReturn(ZONE);
-        AzureConfig azureConfig = AzureConfig.builder().build();
+        AzureConfig azureConfig = AzureConfig.builder().setUseInstanceMetadata(true).build();
         AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
 
         // when

--- a/src/test/java/com/hazelcast/azure/AzureClientTest.java
+++ b/src/test/java/com/hazelcast/azure/AzureClientTest.java
@@ -65,7 +65,7 @@ public class AzureClientTest {
         // given
         given(azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, SCALE_SET, null, ACCESS_TOKEN)).willReturn(ADDRESSES);
 
-        AzureConfig azureConfig = AzureConfig.builder().setUseInstanceMetadata(true).build();
+        AzureConfig azureConfig = AzureConfig.builder().setInstanceMetadataAvailable(true).build();
         AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
 
         // when
@@ -80,7 +80,7 @@ public class AzureClientTest {
         // given
         given(azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, SCALE_SET, TAG, ACCESS_TOKEN)).willReturn(ADDRESSES);
 
-        AzureConfig azureConfig = AzureConfig.builder().setUseInstanceMetadata(true).setTag(TAG).build();
+        AzureConfig azureConfig = AzureConfig.builder().setInstanceMetadataAvailable(true).setTag(TAG).build();
         AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
 
         // when
@@ -109,7 +109,7 @@ public class AzureClientTest {
                                        .setSubscriptionId(subscriptionId)
                                        .setResourceGroup(resourceGroup)
                                        .setScaleSet(scaleSet)
-                                       .setUseInstanceMetadata(false)
+                                       .setInstanceMetadataAvailable(false)
                                        .setTag(TAG)
                                        .build();
         AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
@@ -127,7 +127,7 @@ public class AzureClientTest {
         String location = "location-1";
         given(azureMetadataApi.location()).willReturn(location);
         given(azureMetadataApi.availabilityZone()).willReturn(ZONE);
-        AzureConfig azureConfig = AzureConfig.builder().setUseInstanceMetadata(true).build();
+        AzureConfig azureConfig = AzureConfig.builder().setInstanceMetadataAvailable(true).build();
         AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
 
         // when

--- a/src/test/java/com/hazelcast/azure/AzureDiscoveryStrategyTest.java
+++ b/src/test/java/com/hazelcast/azure/AzureDiscoveryStrategyTest.java
@@ -72,10 +72,14 @@ public class AzureDiscoveryStrategyTest {
     public void newValidProperties() {
         // given
         Map<String, Comparable> properties = new HashMap<String, Comparable>();
+        properties.put("tenant-id", "subscription-id-1");
+        properties.put("client-id", "subscription-id-1");
+        properties.put("client-secret", "subscription-id-1");
         properties.put("subscription-id", "subscription-id-1");
         properties.put("resource-group", "resource-group-1");
         properties.put("scale-set", "scale-set-1");
         properties.put("tag", "tag-1=value-1");
+        properties.put("use-instance-metadata", Boolean.FALSE);
 
         // when
         new AzureDiscoveryStrategy(properties);

--- a/src/test/java/com/hazelcast/azure/AzureDiscoveryStrategyTest.java
+++ b/src/test/java/com/hazelcast/azure/AzureDiscoveryStrategyTest.java
@@ -79,7 +79,7 @@ public class AzureDiscoveryStrategyTest {
         properties.put("resource-group", "resource-group-1");
         properties.put("scale-set", "scale-set-1");
         properties.put("tag", "tag-1=value-1");
-        properties.put("use-instance-metadata", Boolean.FALSE);
+        properties.put("instance-metadata-available", Boolean.FALSE);
 
         // when
         new AzureDiscoveryStrategy(properties);

--- a/src/test/java/com/hazelcast/azure/UtilsTest.java
+++ b/src/test/java/com/hazelcast/azure/UtilsTest.java
@@ -17,34 +17,33 @@ package com.hazelcast.azure;
 
 import org.junit.Test;
 
-import static com.hazelcast.azure.Utils.isAllBlank;
-import static com.hazelcast.azure.Utils.isAllNotBlank;
-import static com.hazelcast.azure.Utils.isBlank;
+import static com.hazelcast.azure.Utils.isAllFilled;
+import static com.hazelcast.azure.Utils.isAnyFilled;
+import static com.hazelcast.azure.Utils.isEmpty;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class UtilsTest {
     @Test
-    public void isBlankTest(){
-        assertFalse(isBlank("test-string"));
-        assertFalse(isBlank(" test-string-with-initial-whitespace"));
-        assertTrue(isBlank(""));
-        assertTrue(isBlank(null));
+    public void isEmptyTest(){
+        assertFalse(isEmpty("test-string"));
+        assertFalse(isEmpty(" test-string-with-initial-whitespace"));
+        assertTrue(isEmpty(""));
+        assertTrue(isEmpty(null));
     }
 
     @Test
-    public void isAllBlankTest(){
-        assertFalse(isAllBlank("test-string-1", "test-string-2"));
-        assertFalse(isAllBlank("test-string-1", ""));
-        assertTrue(isAllBlank("", "", null));
+    public void isAllFilledTest(){
+        assertTrue(isAllFilled("test-string-1", "test-string-2"));
+        assertFalse(isAllFilled("test-string-1", ""));
+        assertFalse(isAllFilled("", "", null));
     }
 
     @Test
-    public void isAllNotBlankTest(){
-        assertTrue(isAllNotBlank("test-string-1", "test-string-2"));
-        assertFalse(isAllNotBlank("test-string-1", ""));
-        assertFalse(isAllNotBlank("", "", null));
+    public void isAnyFilledTest(){
+        assertTrue(isAnyFilled("test-string-1", "test-string-2"));
+        assertTrue(isAnyFilled("test-string-1", ""));
+        assertFalse(isAnyFilled("", "", null));
     }
-
 
 }

--- a/src/test/resources/test-azure-config.xml
+++ b/src/test/resources/test-azure-config.xml
@@ -38,7 +38,7 @@
                         <property name="resource-group">RESOURCE_GROUP</property>
                         <property name="scale-set">SCALE_SET</property>
                         <property name="tag">TAG_KEY=HZLCAST001</property>
-                        <property name="use-instance-metadata">false</property>
+                        <property name="instance-metadata-available">false</property>
                     </properties>
                 </discovery-strategy>
             </discovery-strategies>

--- a/src/test/resources/test-azure-config.xml
+++ b/src/test/resources/test-azure-config.xml
@@ -38,6 +38,7 @@
                         <property name="resource-group">RESOURCE_GROUP</property>
                         <property name="scale-set">SCALE_SET</property>
                         <property name="tag">TAG_KEY=HZLCAST001</property>
+                        <property name="use-instance-metadata">false</property>
                     </properties>
                 </discovery-strategy>
             </discovery-strategies>


### PR DESCRIPTION
This PR adds `use-instance-metadata` which enables/disables usage of Azure Instance Metadata service when retrieving current configuration parameters. Also, the README is updated with a better flow.