### PR TITLE
Correct the groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.hazelcast.azure:hazelcast-azure:${hazelcast-azure-version}'
+    compile 'com.hazelcast:hazelcast-azure:${hazelcast-azure-version}'
 }
 ```
 
@@ -38,7 +38,7 @@ For Maven:
 ```xml
 <dependencies>
     <dependency>
-        <groupId>com.hazelcast.azure</groupId>
+        <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-azure</artifactId>
         <version>${hazelcast-azure-version}</version>
     </dependency>


### PR DESCRIPTION
From what I see on Maven Central and in this project's `pom.xml`, the groupId that is used is `com.hazelcast`, and not `com.hazelcast.azure` (which was used in the older releases from 2016)